### PR TITLE
feat: centralize table numbering in single source of truth

### DIFF
--- a/SAYC-EXPLAINED.md
+++ b/SAYC-EXPLAINED.md
@@ -1,0 +1,632 @@
+# SAYC System Explained
+
+Every bid in Standard American Yellow Card explained with reasoning, common mistakes, and cross-references.
+
+> **How to use this document:** This companion to [SAYC-SYSTEM.md](SAYC-SYSTEM.md) explains *why* each bid exists and how it fits into the system. Written for bridge players familiar with basic bidding who want to understand the logic behind SAYC. For the full reference with exact point ranges and conventions, see [systems/SAYC.md](systems/SAYC.md).
+
+---
+
+## Table of Contents
+
+1. [Opening Bids](#opening-bids)
+2. [Defense After Opponent's Opening](#defense-after-opponents-opening)
+3. [Responses to 1NT](#responses-to-1nt)
+4. [Responses to 1♣](#responses-to-1)
+5. [Responses to 1♦](#responses-to-1-1)
+6. [Responses to 1♥](#responses-to-1-2)
+7. [Responses to 1♠](#responses-to-1-3)
+8. [Strong 2♣ Opening](#strong-2-opening)
+9. [Weak Two Bids](#weak-two-bids)
+10. [Opener's Rebids](#openers-rebids)
+11. [Jacoby 2NT Convention](#jacoby-2nt-convention)
+12. [Ace Asking (4NT)](#ace-asking-4nt)
+13. [Competitive Bidding](#competitive-bidding)
+
+---
+
+## Opening Bids
+
+| Bid | HCP | Description | Why / How |
+|-----|-----|-------------|-----------|
+| 1♣ | 13-21 | 3+♣, bid with 3-3 minors | The "catch-all" minor opening. With 13-21 HCP, no 5-card major, and no 15-17 balanced hand, open the longer minor. With 3-3 in minors, 1♣ is the ACBL convention because it keeps bidding lower and responder can still bid diamonds. The 3-card minimum allows every balanced hand (like 4-4-3-2) to open at the 1-level. |
+| 1♦ | 13-21 | 4+♦ (or 3♦ with 4-4-3-2), bid with 4-4 minors | With 4-4 in minors, open 1♦ so partner's 2♣ response doesn't bypass the diamond fit. The rare 3-card 1♦ opening occurs with exactly 4-4-3-2 shape (4 in each major, 3♦, 2♣) since opening 1♣ with only 2 clubs is worse. |
+| 1♥ | 13-21 | 5+♥ | SAYC requires 5 cards to open a major. This ensures that when responder raises with 3-card support, you have at least an 8-card fit. Five-card majors are the cornerstone of Standard American bidding. |
+| 1♠ | 13-21 | 5+♠ | Same 5-card requirement as hearts. With 5-5 in the majors, open 1♠ (the higher-ranking suit) so you can cheaply rebid 2♥ and show both suits. |
+| 1NT | 15-17 | Balanced (may include 5-card major) | The narrow 3-point range (15-17) immediately describes your hand to partner within a tight window. Balanced means no void, no singleton, and at most one doubleton. SAYC allows a 5-card major in 1NT because the hand may play better in notrump with 15-17 balanced. |
+| 2♣(!) | 22+ | Strong artificial, or 9+ playing tricks | The only strong artificial opening in SAYC. It says nothing about clubs; it tells partner "I have a monster hand." Using 22+ as the threshold keeps the 1-level range (13-21) manageable. Hands with 9+ playing tricks also qualify even with fewer HCP, since they can make game opposite very little. |
+| 2♦ | 5-11 | Weak, 6+♦ | A preemptive opening that disrupts opponents' bidding while describing your hand accurately: a long suit with limited high-card strength. The 6-card minimum ensures a safe trump suit. |
+| 2♥ | 5-11 | Weak, 6+♥ | Same preemptive purpose as 2♦. Weak twos in majors are especially effective because they consume more bidding space from opponents. |
+| 2♠ | 5-11 | Weak, 6+♠ | The most effective weak two because spades is the highest-ranking suit, forcing opponents to start at the 3-level. |
+| 2NT | 20-21 | Balanced | Too strong for 1NT (15-17) but not strong enough for 2♣ (22+). The 2NT opening fills this gap perfectly. Responder uses Stayman (3♣) and transfers (3♦/3♥) just like over 1NT. |
+| 3♣/♦/♥/♠ | 5-11 | 7+ card suit, preemptive | One level higher than weak twos, requiring one more card in the suit. The 7-card suit provides safety (you can afford to go down a few tricks) while consuming enormous bidding space from opponents. Follows the Rule of 2/3/4 for acceptable risk. |
+| 3NT | 25-27 | Balanced | Extremely rare. Can also be reached via 2♣ then rebid 3NT. Opening 3NT directly is simpler but less flexible since partner cannot use Stayman/transfers. |
+| 4♣/♦ | 5-11 | 8+ card suit, preemptive | Very aggressive preempts with freakish distribution. The 8-card suit is its own protection against heavy penalties. |
+| 4♥/♠ | - | 7-8 playing tricks, preemptive | These are to-play bids based on playing tricks rather than HCP. A hand like ♠KQJTxxxx with a side ace has 7-8 tricks and is worth opening 4♠. |
+
+### Why These Ranges?
+
+**Why 13-21 for 1-level openings?** The traditional "Rule of 20" (HCP + length of two longest suits >= 20) means most 13-point hands qualify. The ceiling of 21 is set by the 2♣ opening (22+). This 9-point range is wide but manageable because opener's rebid narrows it.
+
+**Why 15-17 for 1NT?** This is the most popular NT range worldwide. It balances two concerns: (1) strong enough that responder can judge game prospects accurately, (2) not so strong that you rarely hold it. The ACBL chose 15-17 as the standard after decades of experience with both 15-17 and 16-18 ranges.
+
+**Why 5-11 for weak twos?** Below 5 HCP, you risk a huge penalty with no safety. Above 11, the hand is too close to opening values and partner might misjudge. The wide range (5-11) means vulnerability and position matter when deciding whether to open weak.
+
+### Common Mistakes
+
+- **Opening 1♦ with 3 diamonds and 4-3-3-3**: Only open 1♦ with 3 cards when you have 4-4-3-2. With 4-3-3-3, open 1♣ (the 3-card minor you have).
+- **Thinking 1NT denies a 5-card major**: SAYC explicitly allows opening 1NT with a 5-card major when balanced and 15-17. Many players from other systems find this surprising.
+- **Opening a weak two with a 4-card major on the side**: A weak 2♦ with 4 hearts could cause you to miss a heart fit. Avoid it.
+- **Opening 2♣ with 20-21 balanced**: That's a 2NT opening. 2♣ is 22+.
+
+---
+
+## Defense After Opponent's Opening
+
+### After Opponent Opens 1X
+
+| Action | HCP | Description | Why / How |
+|--------|-----|-------------|-----------|
+| PASS | 0-7 | Weak, no action | Below the threshold for any competitive action. Bidding here risks a penalty with no upside. |
+| DBL | 12+ | Takeout, 4+ in unbid suits | A takeout double says "I have opening values and support for the unbid suits." It's the most flexible competitive tool because it lets partner choose the trump suit. Requires 4+ cards in each unbid suit (or very strong). |
+| DBL | 17+ | Any shape, will bid own suit next | With 17+, you double first then bid your suit. This sequence shows a hand too strong for a simple overcall (which caps at 16). Partner knows you have extra values. |
+| 1Y | 8-16 | 5+ card suit, one-level overcall | A 1-level overcall is relatively safe (you're not forcing partner to respond at the 2-level), so the range is wide (8-16). The 5-card suit requirement ensures a real suit for lead-directing purposes. |
+| 1NT | 15-18 | Balanced with stopper(s) | Like an opening 1NT but in competition. The stopper requirement is critical because without it, opponents can run their suit against your notrump contract. The range is 15-18 (slightly wider than opening 1NT) because you need extra for the competitive position. |
+| 2Y | 10-16 | 5+ card suit, two-level overcall | Higher minimum (10 vs 8) than a 1-level overcall because you're forcing partner to the 2-level to support you. Poor suit quality at the 2-level with 8 HCP is a recipe for disaster. |
+| 2X | - | Michaels cuebid, 5-5 two-suiter | Cuebidding the opponent's suit (which you obviously don't want to play in) is used conventionally to show a two-suited hand. It efficiently describes 5-5 shape in one bid. |
+| 2NT | - | Unusual NT, 5-5 in two lowest unbid | Like Michaels, this shows a two-suiter but specifically the two lowest unbid suits. Bidding 2NT in a competitive auction would rarely be natural (you'd need stoppers and would often double instead). |
+| 3Y | 5-11 | 7+ card suit, preemptive jump overcall | A jump overcall in SAYC is weak (not strong, as in some older systems). It preempts opponents while showing a long suit and limited values, same logic as a preemptive opening. |
+
+### Michaels Cuebid Details
+
+| Opponent Opens | Cuebid Shows | Why |
+|----------------|--------------|-----|
+| 1♣ | Both majors (5-5) | Cuebidding a minor shows both majors. This is the most valuable use since finding a major fit is highest priority. |
+| 1♦ | Both majors (5-5) | Same logic as over 1♣. |
+| 1♥ | ♠ + minor (5-5) | Over a major, Michaels shows the other major plus an unspecified minor. Partner bids 2NT to ask which minor. |
+| 1♠ | ♥ + minor (5-5) | Same structure as over 1♥: the other major plus an unspecified minor. |
+
+### Unusual 2NT Details
+
+| Opponent Opens | 2NT Shows | Why |
+|----------------|-----------|-----|
+| 1♣ | ♦ + ♥ | The two lowest unbid suits after clubs are diamonds and hearts. |
+| 1♦ | ♣ + ♥ | The two lowest unbid suits after diamonds are clubs and hearts. |
+| 1♥ | ♣ + ♦ | Over a major, the two lowest unbid suits are always the minors. |
+| 1♠ | ♣ + ♦ | Same as over 1♥: both minors. |
+
+### Common Mistakes
+
+- **Making a takeout double without support for all unbid suits**: A takeout double with 4-1-4-4 over 1♠ works (support for clubs, diamonds, hearts). But doubling 1♠ with 1-4-4-4 is fine too since the singleton is in their suit.
+- **Overcalling with a 4-card suit**: SAYC overcalls promise 5+ cards. With a good 4-card suit and 12+, prefer a takeout double.
+- **Confusing Michaels strength**: Michaels is either weak (below opening) or very strong (17+, planning to bid again). With a medium hand (12-16), just overcall naturally.
+
+---
+
+## Responses to 1NT
+
+Opening 1NT shows **15-17 HCP, balanced**.
+
+### Basic Responses
+
+| Response | HCP | Meaning | Why / How |
+|----------|-----|---------|-----------|
+| PASS | 0-7 | No game interest | Even opposite a 17-point maximum, combined total is only 24, well short of the 25 typically needed for 3NT. Passing is almost always right. |
+| 2♣(!) | 8+ | Stayman, asking for 4-card major | The most common convention in bridge. With 8+ HCP and a 4-card major, you want to find a 4-4 major fit (which usually plays better than 3NT). Stayman asks opener to bid a 4-card major or 2♦ to deny. |
+| 2♦(!) | ANY | Jacoby Transfer to ♥, 5+♥ | Transfers let the strong hand (1NT opener) be declarer, hiding its cards from the defense. Also lets responder describe hand strength on the next bid. With 0 HCP and 5+♥, transfer and pass. With 10+ and 5♥, transfer then bid 3NT to offer a choice of games. |
+| 2♥(!) | ANY | Jacoby Transfer to ♠, 5+♠ | Same logic as 2♦ transfer. The strong hand plays the contract. |
+| 2♠(!) | ANY | Transfer to 3♣ (weak minor) | Used to escape from 1NT into a long minor suit when your hand is very weak. 1NT could be a disaster with a weak hand and a long minor. |
+| 2NT | 8-9 | Balanced, game invite | Combined total is 23-26. Sometimes enough for game (25+), sometimes not. This invites opener to bid 3NT with a maximum (17) and pass with a minimum (15). |
+| 3♣ | 10-12 | 6+♣, 2 of top 3 honors, GI | Shows a real club suit with quality honors. Invitational because with 10-12 opposite 15-17, game is possible but not certain. The honor requirement ensures the suit will produce tricks. |
+| 3♦ | 10-12 | 6+♦, 2 of top 3 honors, GI | Same as 3♣ but in diamonds. |
+| 3♥ | 10+ | 6+♥, slam interest | With 6 hearts and 10+, game is certain (combined 25+), so this jump must show slam interest. With just game values and 6 hearts, you'd transfer then bid 4♥ instead. |
+| 3♠ | 10+ | 6+♠, slam interest | Same logic as 3♥. |
+| 3NT | 10-15 | To play | Combined total is 25-32. Enough for game, not enough for slam. A direct bid of 3NT denies a 5-card major (you'd transfer first) and denies a 4-card major interest (you'd use Stayman). |
+| 4♣(!) | - | Gerber, asking for aces | In notrump auctions, 4♣ replaces Blackwood (4NT) for ace-asking. This is because 4NT over 1NT is needed as a quantitative (non-conventional) raise. Gerber saves bidding space by asking at the 4-level. |
+| 4♦(!) | - | Texas Transfer to ♥ | Like a Jacoby Transfer but at the 4-level. Used with 6+♥ and game values when you just want to play 4♥. The advantage over transferring at 2-level then bidding 4♥ is that it keeps the auction cleaner and avoids ambiguity. |
+| 4♥(!) | - | Texas Transfer to ♠ | Same as 4♦ Texas but for spades. |
+| 4NT | 16-17 | Quantitative slam invite | Combined total is 31-34. A small slam (33+ is typical) is possible but not certain. This asks opener to bid 6NT with a maximum (17) and pass with a minimum (15). This is NOT Blackwood; in notrump auctions, 4NT is always quantitative. |
+| 5NT | 20-21 | Quantitative grand slam invite | Combined total is 35-38. Grand slam (37 is the magic number) is possible. Opener bids 7NT with maximum, 6NT with minimum. |
+| 6NT | 18-19 | To play | Combined total is 33-36. Enough for small slam, not quite enough to invite grand. |
+
+### Why Stayman Requires 8+ HCP
+
+Stayman is only useful if you can act on the information. With fewer than 8 HCP, even finding a 4-4 major fit won't produce game, and you've given opponents information about your hand for no benefit. The exception is "Weak Stayman" (passing opener's 2♦/♥/♠ rebid) with a very distributional hand seeking a better partscore.
+
+### Why Transfers?
+
+Jacoby Transfers serve three purposes:
+1. **Right-siding**: The 1NT opener (stronger hand) becomes declarer, so the opening lead goes into the strong hand rather than through it.
+2. **Flexibility**: After transferring, responder can pass (weak), invite (medium), or force to game (strong), all while having already shown the 5-card suit.
+3. **Extra bidding space**: Responder gets two bids to describe their hand instead of one.
+
+### Stayman Continuations
+
+After opener answers Stayman, responder's next bid narrows the description:
+
+- **Found a fit**: Raise the major (invitational with 8-9, game with 10+)
+- **No fit found (2♦ response)**: Bid 2NT to invite, 3NT to play, or show a 5-card suit
+- **Weak Stayman escape**: Pass any 2-level response with a weak hand (rare tactic)
+
+### Transfer Continuations
+
+After transferring and opener completes it, responder describes strength:
+
+- **Pass**: Weak (0-7), just wanted to play in the major
+- **2NT**: Invitational (8-9) with exactly 5 cards, offering opener a choice between 3 of the major and 3NT
+- **Raise to 3 of major**: Invitational (8-9) with 6+ cards
+- **3NT**: Game values (10-15) with exactly 5, offering choice of games
+- **4 of major**: Game values (10+) with 6+, to play
+- **New suit**: Game forcing (10+), showing a second suit to help find the best contract
+
+### Common Mistakes
+
+- **Using Stayman with 4-3-3-3 and only one 4-card major**: If opener denies your major (bids 2♦), you have no good rebid. With 8-9, you'd bid 2NT (which you could have done without Stayman). Only use Stayman when you can handle all three responses.
+- **Bidding 4NT as Blackwood over 1NT**: Over notrump openings, 4NT is always quantitative (inviting 6NT), never Blackwood. Use Gerber (4♣) to ask for aces.
+- **Transferring then bidding 2NT with 6 cards**: With 6+ cards and 8-9, bid 3 of your major (invitational with a fit). 2NT after a transfer shows exactly 5 cards.
+
+---
+
+## Responses to 1♣
+
+Opening 1♣ shows **13-21 HCP, 3+♣**.
+
+| Response | HCP | Meaning | Why / How |
+|----------|-----|---------|-----------|
+| PASS | 0-5 | Weak | With fewer than 6 points, you cannot guarantee a safe contract above 1♣. Let partner play their contract. |
+| 1♦ | 6+ | 4+♦, forcing | Bidding a new suit at the 1-level is forcing (opener must bid again). With 4+ diamonds and 6+ HCP, show your suit. Bid "up the line" with two 4-card suits (bid the lower-ranking one first to avoid missing a fit). |
+| 1♥ | 6+ | 4+♥, forcing | Major suits are priority in bridge because major-suit games require only 10 tricks (vs 11 for minor games). Always show a 4-card major when you can. |
+| 1♠ | 6+ | 4+♠, forcing | Same priority as hearts. With both 4-card majors, bid 1♥ first (up the line) so opener can show spades at the 1-level if they have them. |
+| 1NT | 6-10 | Balanced, no 4-card major, NF | Denies a 4-card major (you'd bid it) and denies invitational values (you'd bid 2NT). This is non-forcing; opener can pass with a balanced minimum. |
+| 2♣ | 6-10 | 5+♣ support | A simple raise showing club support. The 5-card requirement exists because opener may have only 3 clubs; you need combined 8 cards for a decent fit. |
+| 2♦ | 10+ | 5+♦, forcing | A new suit at the 2-level promises more values (10+) than at the 1-level (6+) because you're committing the partnership to a higher level. The 5-card minimum ensures a real suit. |
+| 2♥ | 10+ | 5+♥, forcing | Same logic: 2-level new suit = 10+ HCP, 5+ cards. Shows a hand too strong for 1♥ (which tops out at weak hands that bid and pass) but requires showing the suit. |
+| 2♠ | 10+ | 5+♠, forcing | Same structure. |
+| 2NT | 11-12 | Balanced, no 4-card major, GI | Too strong for 1NT (6-10) but not enough for 3NT (13-15). Invites opener to bid 3NT with extras. Denies a 4-card major. |
+| 3♣ | 10-12 | 5+♣, limit raise | A jump raise showing invitational values with club support. Opener passes with minimum, bids 3NT or higher with extras. |
+| 3NT | 13-15 | Balanced, no 4-card major, to play | Combined total is 26-36, enough for game. Denies a 4-card major and denies interest in playing in clubs. |
+| 4♣ | 13+ | 5+♣, slam interest | A jump to 4♣ bypasses 3NT, so it must show slam interest (otherwise you'd just bid 3NT). |
+| Jump shift | 19+ | 4+ cards, slam interest | A jump to 2♥, 2♠, or 3♦ shows a very powerful hand interested in slam. This is the strongest response short of bidding slam directly. |
+
+### Common Mistakes
+
+- **Responding 1♦ with 5 diamonds and a 4-card major**: Bid the major first. Finding a major fit is more important since major games are easier to make (10 tricks vs 11 for minors). You can always show diamonds later.
+- **Raising to 2♣ with only 3-card support**: Opener might have only 3 clubs, giving you just a 6-card fit. Prefer 1NT with 3-card support.
+
+---
+
+## Responses to 1♦
+
+Opening 1♦ shows **13-21 HCP, 4+♦** (or 3♦ with 4-4-3-2).
+
+| Response | HCP | Meaning | Why / How |
+|----------|-----|---------|-----------|
+| PASS | 0-5 | Weak | Same as over 1♣. Can't safely go higher. |
+| 1♥ | 6+ | 4+♥, forcing | Priority: show majors first. With both majors, bid 1♥ (up the line). |
+| 1♠ | 6+ | 4+♠, forcing | Show the major. If you also have hearts, you should have bid 1♥ first, so 1♠ tends to deny 4 hearts (unless you have 5+ spades). |
+| 1NT | 6-10 | Balanced, no 4-card major, NF | Same as over 1♣. Denies a biddable major and shows minimum values. |
+| 2♣ | 10+ | 4+♣, forcing | Over 1♦, bidding 2♣ is a new suit at the 2-level, so it promises 10+ HCP. Only 4 cards needed (vs 5 over 1♣) because you're at the 2-level naturally. |
+| 2♦ | 6-10 | 4+♦ support | A simple raise. Since opener usually has 4+ diamonds, 4-card support gives an 8+ card fit. |
+| 2♥ | 10+ | 5+♥, forcing | Two-level new suit: 10+ HCP, 5+ cards. |
+| 2♠ | 10+ | 5+♠, forcing | Same structure. |
+| 2NT | 11-12 | Balanced, no 4-card major, GI | Invitational, same logic as over 1♣. |
+| 3♦ | 10-12 | 5+♦, limit raise | Invitational raise with good diamond support. |
+| 3NT | 13-15 | Balanced, no 4-card major, to play | Game values, balanced, no major to show. |
+| Jump shift | 19+ | 4+ cards, slam interest | Same powerful response as over 1♣. |
+
+### Common Mistakes
+
+- **Raising 1♦ to 2♦ with only 3-card support**: Opener might have opened 1♦ with only 3 cards (4-4-3-2 shape). Prefer 1NT with only 3-card support unless your hand is very distributional.
+
+---
+
+## Responses to 1♥
+
+Opening 1♥ shows **13-21 HCP, 5+♥**.
+
+| Response | HCP | Meaning | Why / How |
+|----------|-----|---------|-----------|
+| PASS | 0-5 | Weak | Not enough to respond. |
+| 1♠ | 6+ | 4+♠, forcing one round | The only suit you can bid at the 1-level. Shows 4+ spades and 6+ HCP. Does NOT deny heart support; you may raise hearts later. Forcing for one round. |
+| 1NT | 6-10 | No fit, no suit at 1-level | A catch-all response when you can't raise hearts (fewer than 3), can't bid 1♠ (fewer than 4), and don't have the 10+ HCP needed for a 2-level suit bid. May be passed by opener. |
+| 2♣ | 10+ | 4+♣, promises rebid | A 2-level new suit showing 10+ HCP. "Promises rebid" means you'll bid again if opener makes a minimum rebid, ensuring the auction continues. |
+| 2♦ | 10+ | 4+♦, promises rebid | Same as 2♣. |
+| 2♥ | 6-10 | 3+♥ support, simple raise | The most common response. With 3+ hearts and 6-10 HCP, raise to show support. Opener needs 5 hearts to open, so 3-card support guarantees an 8-card fit. |
+| 2NT(!) | 13+ | Jacoby 2NT, 4+♥, GF | The game-forcing raise of partner's major. Shows 4+ trump support (important for potential slam) and 13+ HCP. This replaces the old-fashioned direct jump to game, which wasted bidding space. See [Jacoby 2NT Convention](#jacoby-2nt-convention). |
+| 3♣ | 10-12 | 5+♣, GI | Invitational with a long club suit. Shows 10-12 HCP and a real 5-card suit. Not forcing. |
+| 3♦ | 10-12 | 5+♦, GI | Same as 3♣ but in diamonds. |
+| 3♥ | 10-12 | 3-4♥, limit raise | An invitational raise. Opener passes with minimum (13-14), bids game with extras (15+). This is one of the most important bids in SAYC: showing you're close to game but not quite there. |
+| 3NT | 15-17 | Balanced, 2-card support | A rare bid showing a flat hand with game values but only 2-card heart support. Opener can pass or correct to 4♥ with a long suit. |
+| 4♥ | 6-10 | 5+♥, distributional, preemptive | A jump to game with great trump support (5+) but limited HCP. The distribution (shortness somewhere) provides playing strength beyond the HCP count. This bid is preemptive, making it hard for opponents to compete. |
+| Jump shift | 19+ | 4+ cards, slam interest | A jump to 2♠, 3♣, or 3♦ showing 19+ HCP and slam interest. Very rare but very strong. |
+
+### Why Jacoby 2NT Instead of a Direct Raise to Game?
+
+Bidding 1♥ - 4♥ directly with 13+ HCP wastes all the bidding space between 2NT and 4♥. Jacoby 2NT gets to game eventually but first lets opener describe their hand (shortness, side suits, minimum/maximum), which is critical for slam exploration.
+
+### Common Mistakes
+
+- **Bidding 1NT with 3-card heart support**: Raise to 2♥ instead. Finding the major fit is more important than showing a balanced hand. The only exception is with exactly 6 HCP and 3 small hearts where you judge 1NT may play better.
+- **Jumping to 4♥ with 13+ HCP**: Use Jacoby 2NT (13+ with 4+ support). A jump to 4♥ is a weak preemptive bid, not a strong one.
+- **Bidding 2♣/2♦ with only 8-9 HCP**: A 2-level new suit promises 10+. With 8-9 and no fit, bid 1NT.
+
+---
+
+## Responses to 1♠
+
+Opening 1♠ shows **13-21 HCP, 5+♠**.
+
+| Response | HCP | Meaning | Why / How |
+|----------|-----|---------|-----------|
+| PASS | 0-5 | Weak | Not enough to respond. |
+| 1NT | 6-10 | No fit, no suit at 1-level | Over 1♠, there's no room to bid a new suit at the 1-level. 1NT becomes the default response with 6-10 and no spade support. May be passed. |
+| 2♣ | 10+ | 4+♣, promises rebid | Two-level new suit, 10+ HCP. |
+| 2♦ | 10+ | 4+♦, promises rebid | Same structure. |
+| 2♥ | 10+ | 5+♥, promises rebid | Note: this requires 5 hearts, not 4. Since you're bidding a new suit at the 2-level that doesn't raise opener, you need a real suit. With only 4 hearts, bid 1NT or a minor. |
+| 2♠ | 6-10 | 3+♠ support, simple raise | The standard raise, same logic as over 1♥. Three-card support with an opening 5-card suit guarantees an 8-card fit. |
+| 2NT(!) | 13+ | Jacoby 2NT, 4+♠, GF | Game-forcing raise with 4+ trumps. Same convention as over 1♥. |
+| 3♣ | 10-12 | 5+♣, GI | Invitational, real suit. |
+| 3♦ | 10-12 | 5+♦, GI | Same. |
+| 3♥ | 10-12 | 5+♥, GI | Invitational with a long heart suit. Note this shows hearts, not spade support. |
+| 3♠ | 10-12 | 3-4♠, limit raise | Invitational raise, same as 3♥ over 1♥. Opener decides whether to accept. |
+| 3NT | 15-17 | Balanced, 2-card support | Rare. Shows game values but only doubleton spade support. |
+| 4♠ | 6-10 | 5+♠, distributional, preemptive | Weak hand, great trump support, distributional. Preemptive intent. |
+| Jump shift | 19+ | 4+ cards, slam interest | Very strong response showing slam potential. |
+
+### Common Mistakes
+
+- **Responding 2♥ with only 4 hearts**: Over 1♠, a 2♥ response shows 5+ hearts. With 4 hearts and 10+ HCP, start with 2♣ or 2♦ and bid hearts later.
+- **Passing with 6 HCP and 3-card support**: Always raise with 3+ card support and 6+ points. The 8-card fit is too valuable to conceal.
+
+---
+
+## Strong 2♣ Opening
+
+Opening 2♣(!) shows **22+ HCP**, or **9+ playing tricks**. Artificial and forcing.
+
+### Responses to 2♣
+
+| Response | HCP | Meaning | Why / How |
+|----------|-----|---------|-----------|
+| 2♦(!) | 0-7 | Waiting/Negative, artificial | The default response. Says nothing about diamonds. It just says "I don't have a good suit to show positively." This allows opener to describe their hand at a low level. Even with 7 HCP but no suit with 2 of top 3 honors, bid 2♦. |
+| 2♥ | 8+ | 5+♥, 2 of top 3 honors | A positive response showing a real suit (AK, AQ, or KQ in the suit). Immediately establishes a trump suit and shows values, making slam exploration easier. |
+| 2♠ | 8+ | 5+♠, 2 of top 3 honors | Same quality requirement as 2♥. |
+| 2NT | 8+ | Balanced, positive | Shows 8+ HCP with a balanced hand. No suit good enough for a positive suit response. |
+| 3♣ | 8+ | 5+♣, 2 of top 3 honors | Same quality requirement in clubs. |
+| 3♦ | 8+ | 5+♦, 2 of top 3 honors | Same in diamonds. |
+
+### Opener's Rebids After 2♣ - 2♦
+
+| Rebid | Meaning | Why / How |
+|-------|---------|-----------|
+| 2♥ | 5+♥, forcing | Shows hearts naturally. May stop below game only if both hands are minimum (opener has exactly 22 with 5 hearts, responder has 0-3 HCP). |
+| 2♠ | 5+♠, forcing | Same as 2♥. |
+| 2NT | 22-24 balanced | The balanced strong hand. Systems are "on" (Stayman with 3♣, transfers with 3♦/3♥), same as over a 2NT opening. This is a very common and important sequence. |
+| 3♣ | 5+♣, forcing | Shows clubs naturally. Higher than 2NT, so promises a real suit. |
+| 3♦ | 5+♦, forcing | Shows diamonds naturally. |
+| 3♥ | 6+♥, self-sufficient suit, GF | A jump shows a suit that can play as trumps opposite shortage (like AKQJxx). Game forcing. |
+| 3♠ | 6+♠, self-sufficient suit, GF | Same as 3♥. |
+| 3NT | 25-27 balanced | Too strong for 2NT rebid (22-24). |
+
+### Why 2♦ as Waiting?
+
+The 2♦ waiting response keeps the auction as low as possible. Opener has a big hand and needs room to describe it. By using the cheapest possible response, responder gives opener maximum space. The "negative" label is somewhat misleading since responder might have 7 HCP; they just don't have a suit good enough for a positive bid.
+
+### Second Negative
+
+After 2♣ - 2♦ - 2♥/2♠, responder bids 3♣ as a "second negative" (0-4 HCP). This clarifies that the 2♦ was truly weak, not just waiting. It helps opener judge slam prospects.
+
+### Common Mistakes
+
+- **Passing 2♣**: 2♣ is absolutely forcing. You must respond even with 0 HCP (bid 2♦).
+- **Making a positive response with a poor suit**: 2♥/2♠/3♣/3♦ positive responses require 2 of the top 3 honors (A, K, Q). With KJxxxx and 8 HCP, bid 2♦ first, then show the suit.
+- **Treating 2♣ - 2♦ - 2NT as forcing**: After 2NT (22-24), responder CAN pass with 0-2 HCP. This is one of the few sequences where responder can pass after a 2♣ opening.
+
+---
+
+## Weak Two Bids
+
+2♦/2♥/2♠ show **5-11 HCP** with a **6-card suit**.
+
+### Why Weak Twos?
+
+Weak twos are one of the most important innovations in modern bridge. They serve a dual purpose:
+1. **Preemptive**: They consume bidding space, making it harder for opponents with stronger hands to find their best contract.
+2. **Descriptive**: They tell partner exactly what you have (a 6-card suit, limited values), making it easy for partner to judge what to do.
+
+### Requirements and Reasoning
+
+| Requirement | Why |
+|-------------|-----|
+| 6-card suit | Five cards isn't safe enough at the 2-level; seven is a preempt at the 3-level. Six is the sweet spot. |
+| Reasonable quality (2+ honors) | A suit like 876543 could produce zero tricks. You need some solidity. |
+| No void | A void suggests extreme distribution better suited to a different bid or passing. |
+| No outside 4-card major | An outside major could mean you're missing a fit. A weak 2♦ with 4 hearts might bury a heart contract. |
+| Not suitable for 1-level opening | With 12+ HCP, you should open at the 1-level even with a 6-card suit. |
+
+### Responses to Weak Twos
+
+| Response | HCP | Meaning | Why / How |
+|----------|-----|---------|-----------|
+| PASS | 0-13 | No game interest | With less than 14 HCP, game is unlikely opposite a weak hand. Support partner's preempt by staying quiet. |
+| 2NT(!) | 15+ | Feature ask, forcing | The conventional inquiry. With 15+ HCP, game is possible. You ask opener to describe their hand: minimum vs maximum, and any outside "feature" (A or protected K). |
+| Raise to 3 | - | Invitational or preemptive | Can be either competitive (raising the preempt with fit) or invitational (asking opener to bid game with a maximum). Context and hand strength clarify. |
+| Raise to game | - | To play (often preemptive) | Usually a tactical bid: you know where you want to play, either because you have enough for game or because you want to shut out opponents. |
+| New suit | 15+ | Forcing one round (RONF) | "Raise Only Non-Force" means only a raise of opener's suit is non-forcing. Any new suit is forcing, showing a good hand with a suit of its own. |
+| 3NT | 15-17 | To play, stoppers | You have enough for game in notrump with stoppers in the side suits. Opener's suit provides tricks. |
+
+### The 2NT Feature Ask
+
+After partner's 2NT inquiry:
+
+| Rebid | HCP | Meaning | Why / How |
+|-------|-----|---------|-----------|
+| 3 of own suit | 5-8 | Minimum, no outside feature | The default rebid. "I have nothing extra to show." |
+| New suit | 8-11 | Feature (outside A or protected K) | Shows where your outside values are. This helps partner judge 3NT prospects. A "protected K" means Kx or Kxx, not singleton K. |
+| 3NT | 9-11 | Maximum with solid suit (AKQxxx) | The dream hand for a weak two. A running 6-card suit means 6 tricks in notrump regardless of fit. |
+
+### Common Mistakes
+
+- **Opening a weak 2♦ with a poor suit**: Weak 2♦ is the least effective preempt (opponents can still bid 2♥ and 2♠). Only open weak 2♦ with a genuinely decent suit.
+- **Opening a weak two vulnerable with 5 HCP**: Vulnerability matters. With only 5 HCP vulnerable, the penalty risk is significant. Prefer 8-11 when vulnerable.
+- **Responding 2NT to a weak two with only 13 HCP**: You need 15+ for the feature ask. With 13-14, just pass or raise to 3 as a competitive/invitational bid.
+
+---
+
+## Opener's Rebids
+
+### Strength Categories
+
+| Category | HCP | Description | How Opener Shows It |
+|----------|-----|-------------|---------------------|
+| Minimum | 13-15 | Cheapest rebid | Rebid own suit, support partner cheaply, or bid 1NT. |
+| Medium | 16-18 | Jump or reverse | Jump in own suit, jump-raise partner, reverse to a higher suit, or bid 2NT. |
+| Maximum | 19-21 | Double jump or jump shift | Double-jump in own suit, jump shift to new suit, or bid 3NT. |
+
+### Why Rebids Matter
+
+Opener's rebid is the most important bid in the auction. The opening bid showed a wide range (13-21). The rebid narrows it to one of three categories, and partner can then accurately place the final contract.
+
+### Reverse Bids
+
+A **reverse** is a new suit at the 2-level that is **higher-ranking than the opening suit**. It shows 17+ HCP because it forces the auction higher: responder must go to the 3-level to show preference for opener's first suit.
+
+**Examples:**
+- 1♣ - 1♠ - **2♦** = Reverse (diamonds higher than clubs, 17+)
+- 1♣ - 1♠ - **2♥** = Reverse (hearts higher than clubs, 17+)
+- 1♦ - 1♠ - **2♥** = Reverse (hearts higher than diamonds, 17+)
+
+**Not a reverse:**
+- 1♥ - 1♠ - 2♣ = Not a reverse (clubs lower than hearts), just a minimum new suit
+- 1♣ - 1♦ - 1♥ = Not a reverse (1-level, not 2-level)
+
+### After a 1-Level Response
+
+| Rebid | HCP | Meaning | Why / How |
+|-------|-----|---------|-----------|
+| 1NT | 12-14 | Balanced, no fit | Shows the lower end of the range. Balanced with no support for responder's suit. Non-forcing. |
+| 2NT | 18-19 | Balanced | Jump to 2NT shows 18-19 balanced (too strong for 1NT rebid, not enough for 3NT). Highly invitational. |
+| 3NT | 19-20 | Balanced, stoppers | Shows a hand that wants to play 3NT. Stoppers in unbid suits. |
+| Raise of responder's suit | 13-16 | 4-card support | A simple raise showing 4-card support (if responder bid a major, this confirms an 8-card fit). Minimum to medium. |
+| Jump raise | 17-19 | 4-card support | A jump raise showing extras with support. Highly invitational to game. |
+| Rebid own suit | 13-16 | 6+ cards | Shows a 6-card suit (you already showed 5 with the opening, now confirm a 6th card). Minimum. |
+| Jump rebid own suit | 16-18 | 6+ good cards | Extra length and strength. Medium hand. |
+| New suit (non-reverse) | 13-18 | 4+ cards | A natural bid showing a second suit. Non-reverse (lower than opening suit) doesn't promise extras. |
+| Reverse | 17+ | Higher suit at 2-level | Shows extras because it forces the auction higher. See explanation above. |
+| Jump shift | 19+ | 4+ cards, GF | The strongest rebid, forcing to game. Shows 19+ and a real second suit. |
+
+### After a 1NT Response
+
+After partner responds 1NT (6-10, no major, no fit), opener's options are more limited:
+
+| Rebid | HCP | Meaning | Why / How |
+|-------|-----|---------|-----------|
+| PASS | 12-14 | Balanced minimum | Combined total is 18-24 at best. No game prospects. |
+| 2 of lower suit | 12-16 | 4+ cards in new suit | Shows a second suit. Non-forcing since 1NT response limited responder to 6-10. |
+| 2 of own suit | 12-16 | 6+ cards | Rebids the opening suit showing 6+ cards. Non-forcing. |
+| 2NT | 18-19 | Balanced | Shows a hand too strong for passing 1NT. Invitational to 3NT. |
+| 3 of own suit | 16-18 | 6+ good cards | A jump rebid showing a strong suit and medium values. Invitational. |
+| 3NT | 19-20 | Balanced | Places the contract. Even with partner's minimum 6 HCP, combined total is 25+. |
+
+### Common Mistakes
+
+- **Rebidding a 5-card suit**: Never rebid a 5-card suit. If your opening suit is only 5 cards, bid a new suit, support partner, or bid NT. Rebidding promises 6+.
+- **Making a reverse with 15 HCP**: A reverse shows 17+. With 15-16 and a higher second suit, you must find another rebid (often 1NT or a rebid of your opening suit).
+- **Jump-raising partner with 3-card support**: A raise promises 4-card support. With 3-card support and extra values, bid 1NT or 2NT instead.
+
+---
+
+## Jacoby 2NT Convention
+
+**2NT response to 1♥/1♠** = Forcing raise with **4+ trump support** and **13+ support points**.
+
+### Why Jacoby 2NT Exists
+
+Before Jacoby 2NT, responder with 13+ HCP and 4+ trump support had no good bid:
+- A direct raise to game (4♥/4♠) wastes bidding space and misses slams.
+- Bidding a new suit then jumping in the major is ambiguous.
+
+Jacoby 2NT solves this by creating a single bid that means "I have a game-forcing raise with 4+ trumps." This forces the auction to at least game while keeping space open for slam exploration.
+
+### Opener's Rebids After 1♥ - 2NT(!)
+
+| Rebid | Meaning | Why / How |
+|-------|---------|-----------|
+| 3♣ | Singleton or void in ♣ | Shortness bids are the most useful information for slam bidding. If responder has no wasted values in clubs (no AK or KQ), slam is more likely. |
+| 3♦ | Singleton or void in ♦ | Same logic. |
+| 3♥ | Maximum (15-17), no shortness | Shows a balanced maximum. No singleton or void to show. Responder can evaluate slam prospects based on the combined 28-34+ HCP range. |
+| 3♠ | Singleton or void in ♠ | Shortness in spades. |
+| 3NT | Semi-balanced (15-17), no shortness | Similar to 3♥ but may have a more balanced shape (5-3-3-2). |
+| 4♣ | 5+♣ side suit | Instead of shortness, shows a real second suit. Responder judges if the suits mesh well for slam. |
+| 4♦ | 5+♦ side suit | Same as 4♣. |
+| 4♥ | Minimum (13-14), no shortness | The weakest rebid. Minimum balanced hand with no useful extra feature. Says "I'm minimum, we're probably just playing game." |
+
+### Opener's Rebids After 1♠ - 2NT(!)
+
+Same structure but adjusted for spades as trumps:
+
+| Rebid | Meaning | Why / How |
+|-------|---------|-----------|
+| 3♣ | Singleton or void in ♣ | Shortness. |
+| 3♦ | Singleton or void in ♦ | Shortness. |
+| 3♥ | Singleton or void in ♥ | Shortness in hearts (the bid below trumps). |
+| 3♠ | Maximum (15-17), no shortness | Balanced maximum. |
+| 3NT | Semi-balanced (15-17), no shortness | Balanced maximum, no shortness. |
+| 4♣ | 5+♣ side suit | Second suit. |
+| 4♦ | 5+♦ side suit | Second suit. |
+| 4♥ | 5+♥ side suit | Second suit (hearts). |
+| 4♠ | Minimum (13-14), no shortness | Weakest rebid. Sign-off. |
+
+### How Responder Uses This Information
+
+After learning about opener's hand:
+- **Shortness opposite wasted values**: If opener shows a club singleton and responder has AKx in clubs, those values are partly wasted. Slam is less likely.
+- **Shortness opposite small cards**: If opener shows a club singleton and responder has xxx in clubs, that shortness is pure gold. The small clubs disappear and slam is attractive.
+- **Side suit fit**: If opener shows a 5-card diamond side suit and responder has 3+ diamonds, there's a source of tricks for slam.
+
+### Common Mistakes
+
+- **Using Jacoby 2NT with only 3-card support**: Jacoby 2NT promises 4+ trumps. With 3-card support and 13+, bid a new suit then jump in the major.
+- **Using Jacoby 2NT over a minor opening**: Jacoby 2NT only applies over major openings (1♥/1♠). Over minors, 2NT is a natural invitational bid (11-12).
+- **Forgetting to show shortness**: As opener, shortness is the most valuable information. Always show a singleton/void before showing minimum/maximum.
+
+---
+
+## Ace Asking (4NT)
+
+4NT is **Blackwood** asking for aces (after suit agreement).
+
+### Responses to 4NT
+
+| Response | Aces | Why This Encoding |
+|----------|------|-------------------|
+| 5♣ | 0 or 4 | The cheapest response shows the extreme values (0 or 4). Context always makes it clear which: if you've been bidding slams, it's 4; if you've shown a weak hand, it's 0. |
+| 5♦ | 1 | One ace. |
+| 5♥ | 2 | Two aces. |
+| 5♠ | 3 | Three aces. This is the "danger" response since it's high; the asker must account for this possibility before bidding 4NT. |
+
+### King Asking (5NT)
+
+5NT after 4NT asks for kings. This bid **guarantees all 4 aces** are held by the partnership and invites a grand slam. Kings are counted the same way (6♣ = 0/4, 6♦ = 1, 6♥ = 2, 6♠ = 3).
+
+### When to Use Blackwood
+
+Blackwood is appropriate when:
+- Trump suit is agreed
+- You're missing at most one ace
+- You won't need to worry about trump quality
+
+Blackwood is NOT appropriate when:
+- You have a void (you can't distinguish between partner having the ace of your void suit vs another ace)
+- You have two quick losers in an unbid suit (aces don't help if opponents cash two tricks immediately)
+- No trump suit is agreed (use Gerber in NT auctions)
+
+### Gerber (4♣ over NT)
+
+In notrump auctions, 4♣ replaces Blackwood:
+
+| Response | Aces | Why |
+|----------|------|-----|
+| 4♦ | 0 or 4 | Same encoding as Blackwood but one level lower. |
+| 4♥ | 1 | Saves bidding space compared to Blackwood. |
+| 4♠ | 2 | |
+| 4NT | 3 | Note: 4NT here is NOT Blackwood; it's the Gerber response for 3 aces. |
+
+### Interference Over Blackwood (DOPI)
+
+When an opponent interferes over 4NT:
+
+| Action | Meaning | Why |
+|--------|---------|-----|
+| Double | 0 aces | "D" for Double = 0. Penalty doubles are useless here, so repurpose the bid. |
+| Pass | 1 ace | "P" for Pass = 1. |
+| Next step | 2 aces | Continue up from there. |
+
+### Common Mistakes
+
+- **Bidding 4NT without a trump agreement**: Without agreed trumps, 4NT might be interpreted as natural (quantitative) or confusing. Agree on a trump suit first, then ask.
+- **Using Blackwood with a void**: If you have a void in clubs and partner shows 1 ace, you can't tell if it's the ace of clubs (useless) or another ace (useful). Use cuebidding instead.
+- **Bidding 5NT without all aces accounted for**: The 5NT king-ask promises all 4 aces. If an ace is missing, sign off at 5 of your suit.
+- **Confusing Blackwood and Gerber contexts**: Blackwood (4NT) is for suit auctions. Gerber (4♣) is for notrump auctions. Using the wrong one causes a catastrophic misunderstanding.
+
+---
+
+## Competitive Bidding
+
+### Negative Doubles
+
+After partner opens and opponent overcalls, **double is for takeout** (negative), not penalty.
+
+| Open | Opp | DBL Shows | Why |
+|------|-----|-----------|-----|
+| 1♣ | 1♦ | 4-4 in majors | Opponent's overcall took away your ability to bid 1♦ naturally. Double shows both majors efficiently in one bid. |
+| 1♣ | 1♥ | 4+♠ | You can't bid 1♠ with only 4 spades and minimum values (bidding a suit at the 1-level is fine). Actually, you CAN bid 1♠ here. The double specifically shows 4♠ when you might also have tolerance for other suits. |
+| 1♣ | 1♠ | 4+♥ | Hearts was bypassed by the overcall. Double says "I have hearts." |
+| 1♦ | 1♥ | 4+♠ (1♠ would be 5+) | If you bid 1♠ freely, that shows 5+. Double shows exactly 4 spades. This distinction is valuable for finding 4-4 vs 5-3 fits. |
+| 1♦ | 1♠ | 4+♥ | Hearts was bypassed. Double shows hearts. |
+| 1♥ | 1♠ | Minor suit support | Both majors are taken. Double shows values in the minors. Requires 8+ HCP since it's at the 2-level. |
+| 1♥ | 2♣ | 4+♠ | Spades were "bypassed" by the 2♣ overcall (you'd need 10+ to bid 2♠). Double shows spades more cheaply. |
+| 1♠ | 2♣ | 4+♥ | Hearts were bypassed. Double shows hearts. |
+| 1♠ | 2♥ | Minor suit support | Both majors are taken. Double shows minor-suit values. |
+
+### Why Negative Doubles?
+
+Penalty doubles of low-level overcalls are rare and difficult to execute. Negative doubles repurpose the double bid to solve a far more common problem: showing suits that were bypassed by the opponent's overcall. This is one of the most important conventions in competitive bidding.
+
+### HCP Required by Level
+
+| Level | Minimum HCP | Why |
+|-------|-------------|-----|
+| 1-level | 6+ | Same as a free bid at the 1-level. Low risk. |
+| 2-level | 8+ | Partner may need to bid at the 2-level, so you need extra safety. |
+| 3-level | 10+ | Even more committal. Only double at this level with real values. |
+
+### After Opponent's Takeout Double
+
+When opponent doubles partner's opening, the meaning of your bids changes:
+
+| Action | HCP | Meaning | Why / How |
+|--------|-----|---------|-----------|
+| PASS | 0-5 | Weak | Nothing to say. |
+| RDBL | 10+ | Strength, often denies fit | "We have the majority of the points." This warns opponents that they're in trouble and suggests defending. Often starts a penalty-oriented auction. |
+| 2NT(!) | 10+ | Jordan, limit raise or better | Since opponent's double took away the ability to make a natural limit raise, 2NT is repurposed as a "good raise." Named after Robert Jordan. This is an artificial convention. |
+| 2M | 6-9 | 3+ support | Simple raise, same as without the double. |
+| 3M | 0-6 | Preemptive, 4+ support | Weak hand with great trump support. The jump raise is preemptive (opposite meaning from the limit raise without competition). |
+| Jump suit | 0-6 | Preemptive | Weak, long suit, trying to consume opponents' bidding space. |
+
+### Responses to Overcalls
+
+| Response | Meaning | Why / How |
+|----------|---------|-----------|
+| Simple raise | 6-11, 3+ trump | Standard raise of partner's overcall. Overcaller needs to know about trump support. |
+| Jump raise | Preemptive, 4+ trump | Unlike in uncontested auctions, jump raises of overcalls are weak/preemptive. With invitational+ values, cuebid instead. |
+| 1NT | 9-11, balanced, stopper | Shows a balanced hand with a stopper in opponent's suit. Denies good support for partner. |
+| 2NT (non-jump) | 11-13, balanced | Constructive, balanced. |
+| Cuebid | Limit raise or better | Bidding the opponent's suit shows a good raise of partner's overcall. This is the way to show invitational+ values with support. |
+| New suit | Non-forcing, usually denies fit | A new suit over partner's overcall is not forcing. It shows your own suit and suggests you don't fit partner's. |
+
+### Common Mistakes
+
+- **Making a penalty double when it should be negative**: After partner opens and opponent overcalls at a low level, your double is NEGATIVE (takeout), not penalty. To penalize, pass and let partner reopen with a double.
+- **Forgetting Jordan 2NT after a takeout double**: After 1♠ - (DBL), a bid of 2NT shows a limit raise or better with spade support. It does NOT show a balanced 10-12 hand.
+- **Jump-raising an overcall as invitational**: Jump raises of overcalls are preemptive in SAYC. To invite, use a cuebid of the opponent's suit.
+
+---
+
+## Cross-References
+
+| Topic | Convention Card | Full Reference |
+|-------|-----------------|----------------|
+| Opening Bids | [SAYC-SYSTEM.md - Opening Bids](SAYC-SYSTEM.md#opening-bids) | [SAYC.md - Opening Bids](systems/SAYC.md#opening-bids) |
+| Responses to 1NT | [SAYC-SYSTEM.md - Responses to 1NT](SAYC-SYSTEM.md#responses-to-1nt) | [SAYC.md - Responses to 1NT](systems/SAYC.md#responses-to-1nt) |
+| Major Responses | [SAYC-SYSTEM.md - Responses to 1♥](SAYC-SYSTEM.md#responses-to-1-2) | [SAYC.md - Responses to Major Openings](systems/SAYC.md#responses-to-major-openings) |
+| Minor Responses | [SAYC-SYSTEM.md - Responses to 1♣](SAYC-SYSTEM.md#responses-to-1) | [SAYC.md - Responses to Minor Openings](systems/SAYC.md#responses-to-minor-openings) |
+| Opener's Rebids | [SAYC-SYSTEM.md - Opener's Rebids](SAYC-SYSTEM.md#openers-rebids) | [SAYC.md - Opener's Rebids](systems/SAYC.md#openers-rebids) |
+| Strong 2♣ | [SAYC-SYSTEM.md - Strong 2♣](SAYC-SYSTEM.md#strong-2-opening) | [SAYC.md - Strong 2♣ Opening](systems/SAYC.md#strong-2♣-opening) |
+| Weak Twos | [SAYC-SYSTEM.md - Weak Two Bids](SAYC-SYSTEM.md#weak-two-bids) | [SAYC.md - Weak Two Bids](systems/SAYC.md#weak-two-bids) |
+| Jacoby 2NT | [SAYC-SYSTEM.md - Jacoby 2NT](SAYC-SYSTEM.md#jacoby-2nt-convention) | [SAYC.md - Jacoby 2NT Convention](systems/SAYC.md#jacoby-2nt-convention) |
+| Slam Bidding | [SAYC-SYSTEM.md - Ace Asking](SAYC-SYSTEM.md#ace-asking-4nt) | [SAYC.md - Slam Bidding](systems/SAYC.md#slam-bidding) |
+| Competitive | [SAYC-SYSTEM.md - Competitive](SAYC-SYSTEM.md#competitive-bidding) | [SAYC.md - Competitive Bidding](systems/SAYC.md#competitive-bidding) |
+
+---
+
+*Companion document to [SAYC-SYSTEM.md](SAYC-SYSTEM.md). For differences from our partnership system, see [SAYC-DIFFERENCES.md](SAYC-DIFFERENCES.md). Last updated: March 2026*


### PR DESCRIPTION
## Summary
- Move table number computation from 6 individual pages into `src/data/index.ts`
- `buildTableNumbers()` derives canonical numbers from markdown parse order
- All pages (our-system, sayc, verification + 3 print pages) import `ourSystemTableNumbers` / `saycTableNumbers` instead of computing locally
- Exports `getTableNumber()` and `getTableIndex()` helpers for future use

## Test plan
- [x] `npm run build` passes with all 11 pages generated
- [ ] Verify table numbers on our-system page match before/after
- [ ] Verify table numbers on sayc page match before/after
- [ ] Verify verification page uses canonical our-system numbers
- [ ] Check print pages render correct table numbers