### PR TITLE
fix: hide Other header and shorten TOC titles

### DIFF
--- a/website/src/pages/comparison.astro
+++ b/website/src/pages/comparison.astro
@@ -22,10 +22,17 @@ function formatBid(text: string): string {
     .replace(/♦/g, '<span class="suit-diamond" style="color: #dc2626;">♦</span>');
 }
 
-const tocItems = comparisonSections.map((s) => ({
-  id: s.title.toLowerCase().replace(/[^a-z0-9]+/g, "-"),
-  label: s.title,
-}));
+const tocItems = comparisonSections.map((s) => {
+  let label = s.title;
+  if (label.length > 40 && label.includes(':')) {
+    const parts = label.split(':');
+    label = parts[parts.length - 1].trim();
+  }
+  return {
+    id: s.title.toLowerCase().replace(/[^a-z0-9]+/g, "-"),
+    label,
+  };
+});
 ---
 
 <BaseLayout title="Comparison">

--- a/website/src/pages/our-system.astro
+++ b/website/src/pages/our-system.astro
@@ -18,10 +18,17 @@ for (const section of ourSystemSections) {
 const tableNumberMap = new Map<typeof ourSystemSections[number], number>();
 ourSystemSections.forEach((s, i) => tableNumberMap.set(s, i + 1));
 
-const tocItems = ourSystemSections.map((s) => ({
-  id: s.title.toLowerCase().replace(/[^a-z0-9]+/g, "-"),
-  label: s.title,
-}));
+const tocItems = ourSystemSections.map((s) => {
+  let label = s.title;
+  if (label.length > 40 && label.includes(':')) {
+    const parts = label.split(':');
+    label = parts[parts.length - 1].trim();
+  }
+  return {
+    id: s.title.toLowerCase().replace(/[^a-z0-9]+/g, "-"),
+    label,
+  };
+});
 ---
 
 <BaseLayout title="Our System">
@@ -36,7 +43,9 @@ const tocItems = ourSystemSections.map((s) => ({
     <div class="min-w-0 flex-1 space-y-10">
       {Array.from(grouped.entries()).map(([page, sections]) => (
         <div class="space-y-8">
-          <h2 class="border-b pb-2 text-xl font-semibold text-muted-foreground">{page}</h2>
+          {page !== "Other" && (
+            <h2 class="border-b pb-2 text-xl font-semibold text-muted-foreground">{page}</h2>
+          )}
           {sections.map((section) => (
             <div
               id={section.title.toLowerCase().replace(/[^a-z0-9]+/g, "-")}

--- a/website/src/pages/print/our-system.astro
+++ b/website/src/pages/print/our-system.astro
@@ -28,7 +28,9 @@ function formatBid(text: string): string {
   <div class="print-grid">
     {Array.from(grouped.entries()).map(([page, sections], groupIdx) => (
       <div class:list={["print-grid-item", groupIdx > 1 && ""]}>
-        <div class="print-page-header">{page}</div>
+        {page !== "Other" && (
+          <div class="print-page-header">{page}</div>
+        )}
         {sections.map((section) => (
           <div class="print-section-block">
             <div class="print-section-header" set:html={`<span style="color: #888; font-weight: normal; font-size: 0.85em;">Table ${tableNumberMap.get(section)}:</span> ${formatBid(section.title)}`} />

--- a/website/src/pages/sayc.astro
+++ b/website/src/pages/sayc.astro
@@ -6,10 +6,17 @@ import TableOfContents from "@/components/TableOfContents.astro";
 import { saycSystemSections, isBiddingSection } from "@/data/index";
 import "@/styles/global.css";
 
-const tocItems = saycSystemSections.map((s) => ({
-  id: s.title.toLowerCase().replace(/[^a-z0-9]+/g, "-"),
-  label: s.title,
-}));
+const tocItems = saycSystemSections.map((s) => {
+  let label = s.title;
+  if (label.length > 40 && label.includes(':')) {
+    const parts = label.split(':');
+    label = parts[parts.length - 1].trim();
+  }
+  return {
+    id: s.title.toLowerCase().replace(/[^a-z0-9]+/g, "-"),
+    label,
+  };
+});
 ---
 
 <BaseLayout title="SAYC">


### PR DESCRIPTION
## Summary
- Hide the "Other" group header when sections don't have a page reference (our-system and print/our-system pages)
- Truncate long TOC sidebar labels (>40 chars) to just the last part after the final colon (our-system, sayc, and comparison pages)

Closes #9