### PR TITLE
feat: add collapsible auction tree layout to system pages

### DIFF
--- a/website/src/components/AuctionTreeNode.astro
+++ b/website/src/components/AuctionTreeNode.astro
@@ -1,0 +1,62 @@
+---
+import { BiddingTable } from "@/components/BiddingTable";
+import { GenericTableView } from "@/components/GenericTableView";
+import { isBiddingSection } from "@/data/types";
+import { nodeHasContent, type TreeNode, type SectionInfo } from "@/data/auction-trees";
+
+interface Props {
+  node: TreeNode;
+  sectionMap: Map<string, SectionInfo>;
+}
+
+const { node, sectionMap } = Astro.props;
+
+const info = node.sectionTitle ? sectionMap.get(node.sectionTitle) : undefined;
+const sectionId = node.sectionTitle
+  ? node.sectionTitle.toLowerCase().replace(/[^a-z0-9]+/g, "-")
+  : node.title.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+
+const visibleChildren = (node.children ?? []).filter((child) =>
+  nodeHasContent(child, sectionMap),
+);
+
+const hasContent = info || visibleChildren.length > 0;
+---
+
+{hasContent && (
+  <details
+    open={node.defaultOpen}
+    id={info ? sectionId : undefined}
+    data-toc-target={info ? "" : undefined}
+    class="auction-tree-node scroll-mt-4"
+  >
+    <summary class="cursor-pointer py-2 font-semibold hover:text-primary">
+      {node.title}
+    </summary>
+    <div class="ml-4 border-l-2 border-muted pl-4 mt-2 space-y-4">
+      {info && isBiddingSection(info.section) && (
+        <div class="overflow-x-auto">
+          <BiddingTable
+            tableNumber={info.tableNumber}
+            title={info.section.title}
+            prefix={info.section.prefix}
+            entries={info.section.entries}
+          />
+        </div>
+      )}
+      {info && !isBiddingSection(info.section) && (
+        <div class="overflow-x-auto">
+          <GenericTableView
+            tableNumber={info.tableNumber}
+            title={info.section.title}
+            headers={info.section.headers}
+            rows={info.section.rows}
+          />
+        </div>
+      )}
+      {visibleChildren.map((child) => (
+        <Astro.self node={child} sectionMap={sectionMap} />
+      ))}
+    </div>
+  </details>
+)}

--- a/website/src/data/auction-trees.ts
+++ b/website/src/data/auction-trees.ts
@@ -1,0 +1,196 @@
+import type { SystemSection } from './types';
+
+export interface TreeNode {
+  title: string;
+  sectionTitle?: string;
+  defaultOpen: boolean;
+  children?: TreeNode[];
+}
+
+/**
+ * Tree definitions for collapsible auction groupings.
+ * Nodes with `sectionTitle` render the matching section's table.
+ * Nodes without `sectionTitle` are virtual grouping parents.
+ * Nodes whose `sectionTitle` doesn't match any section are skipped.
+ */
+export const auctionTrees: TreeNode[] = [
+  // 1NT System
+  {
+    title: '1NT Responses',
+    sectionTitle: 'Responses to 1NT: Basic Responses',
+    defaultOpen: true,
+    children: [
+      {
+        title: 'After Stayman: 1NT - 2♣(!)',
+        sectionTitle: 'After Stayman: 1NT - 2♣(!)',
+        defaultOpen: false,
+      },
+      {
+        title: 'After Heart Transfer: 1NT - 2♦(!) - 2♥',
+        sectionTitle: 'After Heart Transfer: 1NT - 2♦(!) - 2♥',
+        defaultOpen: false,
+      },
+      {
+        title: 'After Spade Transfer: 1NT - 2♥(!) - 2♠',
+        sectionTitle: 'After Spade Transfer: 1NT - 2♥(!) - 2♠',
+        defaultOpen: false,
+      },
+      {
+        title: 'Gerber (4♣ over 1NT/2NT)',
+        sectionTitle: 'Gerber (4♣ over 1NT/2NT)',
+        defaultOpen: false,
+      },
+      {
+        title: 'Direct Minor Suit Sequences',
+        sectionTitle: 'Responses to 1NT: Direct Minor Suit Sequences',
+        defaultOpen: false,
+      },
+      {
+        title: 'Slam Invitation Sequences',
+        sectionTitle: 'Responses to 1NT: Slam Invitation Sequences',
+        defaultOpen: false,
+      },
+      {
+        title: 'After Interference Over 1NT',
+        defaultOpen: false,
+        children: [
+          {
+            title: 'After 1NT - Double (Penalty)',
+            sectionTitle: 'After 1NT - Double (Penalty)',
+            defaultOpen: true,
+          },
+          {
+            title: 'After 1NT - 2♣/♦/♥/♠ (Overcall)',
+            sectionTitle: 'After 1NT - 2♣/♦/♥/♠ (Overcall)',
+            defaultOpen: true,
+          },
+        ],
+      },
+    ],
+  },
+  // 2♣ System
+  {
+    title: '2♣ Opening Responses',
+    sectionTitle: 'Responses to 2♣(!)',
+    defaultOpen: true,
+    children: [
+      {
+        title: "Opener's Rebids After 2♣ - 2♦(!)",
+        sectionTitle: "Opener's Rebids After 2♣ - 2♦(!)",
+        defaultOpen: false,
+        children: [
+          {
+            title: 'Continuations After 2♣ - 2♦ - 2NT',
+            sectionTitle: 'Continuations After 2♣ - 2♦ - 2NT',
+            defaultOpen: false,
+          },
+        ],
+      },
+      {
+        title: 'Second Negative',
+        sectionTitle: 'Strong 2♣ Opening: Second Negative',
+        defaultOpen: false,
+      },
+    ],
+  },
+  // Opener's Rebids
+  {
+    title: "Opener's Rebids",
+    defaultOpen: false,
+    children: [
+      {
+        title: 'Strength Categories',
+        sectionTitle: "Opener's Rebids: Strength Categories",
+        defaultOpen: false,
+      },
+      { title: 'After 1♣ - 1♦', sectionTitle: 'After 1♣ - 1♦', defaultOpen: false },
+      { title: 'After 1♣ - 1♥', sectionTitle: 'After 1♣ - 1♥', defaultOpen: false },
+      { title: 'After 1♣ - 1♠', sectionTitle: 'After 1♣ - 1♠', defaultOpen: false },
+      { title: 'After 1♣ - 1NT', sectionTitle: 'After 1♣ - 1NT', defaultOpen: false },
+      { title: 'After 1♦ - 1♥', sectionTitle: 'After 1♦ - 1♥', defaultOpen: false },
+      { title: 'After 1♦ - 1♠', sectionTitle: 'After 1♦ - 1♠', defaultOpen: false },
+      { title: 'After 1♥ - 1♠', sectionTitle: 'After 1♥ - 1♠', defaultOpen: false },
+      { title: 'After 1♥ - 1NT', sectionTitle: 'After 1♥ - 1NT', defaultOpen: false },
+      { title: 'After 1♠ - 1NT', sectionTitle: 'After 1♠ - 1NT', defaultOpen: false },
+      { title: 'After 1♦ - 2♣', sectionTitle: 'After 1♦ - 2♣', defaultOpen: false },
+      { title: 'After 1♣ - 2♣', sectionTitle: 'After 1♣ - 2♣', defaultOpen: false },
+      {
+        title: 'Reverse Bids',
+        sectionTitle: "Opener's Rebids: Reverse Bids",
+        defaultOpen: false,
+      },
+    ],
+  },
+];
+
+/** Collect all sectionTitles from a tree node recursively. */
+function collectSectionTitles(node: TreeNode): string[] {
+  const titles: string[] = [];
+  if (node.sectionTitle) titles.push(node.sectionTitle);
+  for (const child of node.children ?? []) {
+    titles.push(...collectSectionTitles(child));
+  }
+  return titles;
+}
+
+/** Check if a tree node has any matching sections. */
+export function nodeHasContent(
+  node: TreeNode,
+  sectionMap: Map<string, unknown>,
+): boolean {
+  if (node.sectionTitle && sectionMap.has(node.sectionTitle)) return true;
+  return (node.children ?? []).some((child) => nodeHasContent(child, sectionMap));
+}
+
+export interface SectionInfo {
+  section: SystemSection;
+  tableNumber: number;
+}
+
+export type RenderItem =
+  | { type: 'flat'; section: SystemSection; tableNumber: number }
+  | { type: 'tree'; node: TreeNode; sectionMap: Map<string, SectionInfo> };
+
+/**
+ * Transform a flat section list into a render list with tree groupings.
+ * Sections belonging to a tree are grouped under the tree's root.
+ * Sections not in any tree render flat.
+ */
+export function buildRenderList(sections: SystemSection[]): RenderItem[] {
+  const sectionByTitle = new Map<string, SectionInfo>();
+  sections.forEach((s, i) => sectionByTitle.set(s.title, { section: s, tableNumber: i + 1 }));
+
+  const consumed = new Set<string>();
+  const triggerToTree = new Map<string, TreeNode>();
+
+  for (const tree of auctionTrees) {
+    const titles = collectSectionTitles(tree);
+    const existingTitles = titles.filter((t) => sectionByTitle.has(t));
+    if (existingTitles.length === 0) continue;
+
+    for (const t of existingTitles) consumed.add(t);
+
+    // Trigger on the first matching section in document order
+    const firstTitle = sections.find((s) => existingTitles.includes(s.title))?.title;
+    if (firstTitle) triggerToTree.set(firstTitle, tree);
+  }
+
+  const items: RenderItem[] = [];
+  for (const section of sections) {
+    if (triggerToTree.has(section.title)) {
+      items.push({
+        type: 'tree',
+        node: triggerToTree.get(section.title)!,
+        sectionMap: sectionByTitle,
+      });
+    } else if (!consumed.has(section.title)) {
+      items.push({
+        type: 'flat',
+        section,
+        tableNumber: sectionByTitle.get(section.title)!.tableNumber,
+      });
+    }
+  }
+
+  return items;
+}

--- a/website/src/pages/our-system.astro
+++ b/website/src/pages/our-system.astro
@@ -2,26 +2,25 @@
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import { BiddingTable } from "@/components/BiddingTable";
 import { GenericTableView } from "@/components/GenericTableView";
+import AuctionTreeNode from "@/components/AuctionTreeNode.astro";
 import TableOfContents from "@/components/TableOfContents.astro";
 import { ourSystemSections, isBiddingSection } from "@/data/index";
+import { buildRenderList } from "@/data/auction-trees";
 import "@/styles/global.css";
 
-// Group sections by page reference
-const grouped = new Map<string, typeof ourSystemSections>();
-for (const section of ourSystemSections) {
-  const key = section.page || "Other";
-  if (!grouped.has(key)) grouped.set(key, []);
-  grouped.get(key)!.push(section);
-}
+const renderList = buildRenderList(ourSystemSections);
 
-// Assign sequential table numbers across all sections
-const tableNumberMap = new Map<typeof ourSystemSections[number], number>();
-ourSystemSections.forEach((s, i) => tableNumberMap.set(s, i + 1));
-
-const tocItems = ourSystemSections.map((s) => ({
-  id: s.title.toLowerCase().replace(/[^a-z0-9]+/g, "-"),
-  label: s.title,
-}));
+const tocItems = ourSystemSections.map((s) => {
+  let label = s.title;
+  if (label.length > 40 && label.includes(':')) {
+    const parts = label.split(':');
+    label = parts[parts.length - 1].trim();
+  }
+  return {
+    id: s.title.toLowerCase().replace(/[^a-z0-9]+/g, "-"),
+    label,
+  };
+});
 ---
 
 <BaseLayout title="Our System">
@@ -33,25 +32,24 @@ const tocItems = ourSystemSections.map((s) => ({
   </div>
 
   <div class="mt-8 flex gap-8">
-    <div class="min-w-0 flex-1 space-y-10">
-      {Array.from(grouped.entries()).map(([page, sections]) => (
-        <div class="space-y-8">
-          <h2 class="border-b pb-2 text-xl font-semibold text-muted-foreground">{page}</h2>
-          {sections.map((section) => (
-            <div
-              id={section.title.toLowerCase().replace(/[^a-z0-9]+/g, "-")}
-              data-toc-target
-              class="overflow-x-auto scroll-mt-4"
-            >
-              {isBiddingSection(section) ? (
-                <BiddingTable tableNumber={tableNumberMap.get(section)} title={section.title} prefix={section.prefix} entries={section.entries} />
-              ) : (
-                <GenericTableView tableNumber={tableNumberMap.get(section)} title={section.title} headers={section.headers} rows={section.rows} />
-              )}
-            </div>
-          ))}
-        </div>
-      ))}
+    <div class="min-w-0 flex-1 space-y-8">
+      {renderList.map((item) =>
+        item.type === 'tree' ? (
+          <AuctionTreeNode node={item.node} sectionMap={item.sectionMap} />
+        ) : (
+          <div
+            id={item.section.title.toLowerCase().replace(/[^a-z0-9]+/g, "-")}
+            data-toc-target
+            class="overflow-x-auto scroll-mt-4"
+          >
+            {isBiddingSection(item.section) ? (
+              <BiddingTable tableNumber={item.tableNumber} title={item.section.title} prefix={item.section.prefix} entries={item.section.entries} />
+            ) : (
+              <GenericTableView tableNumber={item.tableNumber} title={item.section.title} headers={item.section.headers} rows={item.section.rows} />
+            )}
+          </div>
+        )
+      )}
     </div>
 
     <TableOfContents items={tocItems} />

--- a/website/src/pages/sayc.astro
+++ b/website/src/pages/sayc.astro
@@ -2,14 +2,25 @@
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import { BiddingTable } from "@/components/BiddingTable";
 import { GenericTableView } from "@/components/GenericTableView";
+import AuctionTreeNode from "@/components/AuctionTreeNode.astro";
 import TableOfContents from "@/components/TableOfContents.astro";
 import { saycSystemSections, isBiddingSection } from "@/data/index";
+import { buildRenderList } from "@/data/auction-trees";
 import "@/styles/global.css";
 
-const tocItems = saycSystemSections.map((s) => ({
-  id: s.title.toLowerCase().replace(/[^a-z0-9]+/g, "-"),
-  label: s.title,
-}));
+const renderList = buildRenderList(saycSystemSections);
+
+const tocItems = saycSystemSections.map((s) => {
+  let label = s.title;
+  if (label.length > 40 && label.includes(':')) {
+    const parts = label.split(':');
+    label = parts[parts.length - 1].trim();
+  }
+  return {
+    id: s.title.toLowerCase().replace(/[^a-z0-9]+/g, "-"),
+    label,
+  };
+});
 ---
 
 <BaseLayout title="SAYC">
@@ -22,19 +33,23 @@ const tocItems = saycSystemSections.map((s) => ({
 
   <div class="mt-8 flex gap-8">
     <div class="min-w-0 flex-1 space-y-8">
-      {saycSystemSections.map((section, idx) => (
-        <div
-          id={section.title.toLowerCase().replace(/[^a-z0-9]+/g, "-")}
-          data-toc-target
-          class="overflow-x-auto scroll-mt-4"
-        >
-          {isBiddingSection(section) ? (
-            <BiddingTable tableNumber={idx + 1} title={section.title} prefix={section.prefix} entries={section.entries} />
-          ) : (
-            <GenericTableView tableNumber={idx + 1} title={section.title} headers={section.headers} rows={section.rows} />
-          )}
-        </div>
-      ))}
+      {renderList.map((item) =>
+        item.type === 'tree' ? (
+          <AuctionTreeNode node={item.node} sectionMap={item.sectionMap} />
+        ) : (
+          <div
+            id={item.section.title.toLowerCase().replace(/[^a-z0-9]+/g, "-")}
+            data-toc-target
+            class="overflow-x-auto scroll-mt-4"
+          >
+            {isBiddingSection(item.section) ? (
+              <BiddingTable tableNumber={item.tableNumber} title={item.section.title} prefix={item.section.prefix} entries={item.section.entries} />
+            ) : (
+              <GenericTableView tableNumber={item.tableNumber} title={item.section.title} headers={item.section.headers} rows={item.section.rows} />
+            )}
+          </div>
+        )
+      )}
     </div>
 
     <TableOfContents items={tocItems} />


### PR DESCRIPTION
## Summary
- Add collapsible `<details>/<summary>` tree layout grouping related bidding sections on our-system and sayc pages
- Three tree groups: 1NT system (responses + transfers + interference), 2♣ system (responses + rebids + continuations), and opener's rebids
- Tree definitions in `auction-trees.ts` with recursive `AuctionTreeNode.astro` component
- Sections not in a tree render flat as before; print pages remain unchanged

## Test plan
- [ ] Verify our-system page shows 3 collapsible tree groups (1NT, 2♣, Opener's Rebids)
- [ ] Verify sayc page shows same trees with SAYC-specific sections (Gerber, Strength Categories, etc.)
- [ ] Verify print pages have no `<details>` elements (flat layout preserved)
- [ ] Verify TOC links still scroll to correct sections within trees
- [ ] Verify expanding/collapsing works with browser native disclosure triangle