### PR TITLE
feat: add revision history to print/PDF pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,3 +77,4 @@ The original scans are in Russian (`system-scans/IMG_3951.jpg` to `IMG_3959.jpg`
 - Use SAYC.md as the reference for standard SAYC values
 - Mark differences clearly with **bold** and Diff Type column
 - When SYSTEM.md changes, always propagate to: SYSTEM-COMPARISON.md, SAYC-DIFFERENCES.md, TRANSCRIPTION-ERRORS.md, and website/src/data/difference-explanations.ts
+- When changing system content, update revision history in website/src/data/revisions.ts

--- a/website/src/data/revisions.ts
+++ b/website/src/data/revisions.ts
@@ -1,0 +1,23 @@
+export interface Revision {
+  date: string;
+  version: string;
+  changes: string;
+}
+
+export const ourSystemRevisions: Revision[] = [
+  { date: "2026-03-29", version: "1.0", changes: "Initial transcription from scanned convention cards" },
+  { date: "2026-03-29", version: "1.1", changes: "Applied 20 transcription error corrections" },
+  { date: "2026-03-29", version: "1.2", changes: "Completed scoring reference, added sequence prefixes" },
+  { date: "2026-03-30", version: "1.3", changes: "Added 1NT interference section" },
+];
+
+export const saycRevisions: Revision[] = [
+  { date: "2026-03-29", version: "1.0", changes: "Initial SAYC convention card" },
+  { date: "2026-03-29", version: "1.1", changes: "Scoring reference, sequence prefixes" },
+  { date: "2026-03-30", version: "1.2", changes: "Added 1NT interference section" },
+];
+
+export const transitionGuideRevisions: Revision[] = [
+  { date: "2026-03-29", version: "1.0", changes: "Initial transition guide with 48 annotated differences" },
+  { date: "2026-03-29", version: "1.1", changes: "Separated from SAYC convention card" },
+];

--- a/website/src/pages/print/our-system.astro
+++ b/website/src/pages/print/our-system.astro
@@ -1,6 +1,9 @@
 ---
 import PrintLayout from "@/layouts/PrintLayout.astro";
 import { ourSystemSections, isBiddingSection, type BiddingSection } from "@/data/index";
+import { ourSystemRevisions } from "@/data/revisions";
+
+const latestVersion = ourSystemRevisions[ourSystemRevisions.length - 1].version;
 
 // Group sections by page reference
 const grouped = new Map<string, typeof ourSystemSections>();
@@ -75,5 +78,20 @@ function formatBid(text: string): string {
         ))}
       </div>
     ))}
+  </div>
+
+  <div class="print-section-block" style="margin-top: 2em; border-top: 2px solid #333; padding-top: 1em;">
+    <p style="font-size: 0.75rem; color: #666; margin-bottom: 0.5em;">
+      Version {latestVersion} — Generated {new Date().toISOString().split('T')[0]}
+    </p>
+    <div class="print-section-header">Revision History</div>
+    <table class="print-table">
+      <thead><tr><th>Date</th><th>Version</th><th>Changes</th></tr></thead>
+      <tbody>
+        {ourSystemRevisions.map(r => (
+          <tr><td>{r.date}</td><td>{r.version}</td><td>{r.changes}</td></tr>
+        ))}
+      </tbody>
+    </table>
   </div>
 </PrintLayout>

--- a/website/src/pages/print/sayc.astro
+++ b/website/src/pages/print/sayc.astro
@@ -1,6 +1,9 @@
 ---
 import PrintLayout from "@/layouts/PrintLayout.astro";
 import { saycSystemSections, isBiddingSection, type BiddingSection } from "@/data/index";
+import { saycRevisions } from "@/data/revisions";
+
+const latestVersion = saycRevisions[saycRevisions.length - 1].version;
 
 // Helper to colorize suit symbols
 function formatBid(text: string): string {
@@ -60,5 +63,20 @@ function formatBid(text: string): string {
         </div>
       </div>
     ))}
+  </div>
+
+  <div class="print-section-block" style="margin-top: 2em; border-top: 2px solid #333; padding-top: 1em;">
+    <p style="font-size: 0.75rem; color: #666; margin-bottom: 0.5em;">
+      Version {latestVersion} — Generated {new Date().toISOString().split('T')[0]}
+    </p>
+    <div class="print-section-header">Revision History</div>
+    <table class="print-table">
+      <thead><tr><th>Date</th><th>Version</th><th>Changes</th></tr></thead>
+      <tbody>
+        {saycRevisions.map(r => (
+          <tr><td>{r.date}</td><td>{r.version}</td><td>{r.changes}</td></tr>
+        ))}
+      </tbody>
+    </table>
   </div>
 </PrintLayout>

--- a/website/src/pages/print/transition-guide.astro
+++ b/website/src/pages/print/transition-guide.astro
@@ -2,6 +2,9 @@
 import PrintLayout from "@/layouts/PrintLayout.astro";
 import { saycSystemSections, isBiddingSection, type BiddingSection } from "@/data/index";
 import { diffExplanations, type DiffExplanation } from "@/data/difference-explanations";
+import { transitionGuideRevisions } from "@/data/revisions";
+
+const latestVersion = transitionGuideRevisions[transitionGuideRevisions.length - 1].version;
 
 // Map SAYC-SYSTEM.md section titles to diffExplanation section names
 const sectionMap: Record<string, string> = {
@@ -119,5 +122,20 @@ const minorCount = diffExplanations.filter(d => d.severity === 'minor').length;
         </div>
       </div>
     ))}
+  </div>
+
+  <div class="print-section-block" style="margin-top: 2em; border-top: 2px solid #333; padding-top: 1em;">
+    <p style="font-size: 0.75rem; color: #666; margin-bottom: 0.5em;">
+      Version {latestVersion} — Generated {new Date().toISOString().split('T')[0]}
+    </p>
+    <div class="print-section-header">Revision History</div>
+    <table class="print-table">
+      <thead><tr><th>Date</th><th>Version</th><th>Changes</th></tr></thead>
+      <tbody>
+        {transitionGuideRevisions.map(r => (
+          <tr><td>{r.date}</td><td>{r.version}</td><td>{r.changes}</td></tr>
+        ))}
+      </tbody>
+    </table>
   </div>
 </PrintLayout>


### PR DESCRIPTION
## Summary
- Create `website/src/data/revisions.ts` with version history for all three documents
- Add revision history table with version number and generation date to bottom of each print page (our-system, sayc, transition-guide)
- Update CLAUDE.md with reminder to maintain revision history when changing system content

## Test plan
- [x] `npm run build` passes
- [ ] Verify revision tables appear at bottom of each print page
- [ ] Verify version numbers and dates are correct